### PR TITLE
Updated storageClass for Minio service

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,5 +532,3 @@ In the provision-section of the config.tfvars config file
 
 ## PhenoMeNal help and support
 [For feedback and help](http://phenomenal-h2020.eu/home/help/)
-
-

--- a/playbooks/install-pachyderm-minio-playbook.yml
+++ b/playbooks/install-pachyderm-minio-playbook.yml
@@ -4,7 +4,8 @@
   gather_facts: "no"
   vars:
     # Service version tags
-    minio_version: "RELEASE.2017-12-28T01-21-00Z"
+    minio_version: "RELEASE.2018-01-18T20-33-21Z"
+    minio_storage_class: "object-store-sc"
     pachyderm_version: "1.6.6"
     etcd_version: "v3.2.7"
 
@@ -20,6 +21,7 @@
         minio_secretkey: "{{minio_secretkey}}"
         minio_replicas: "{{minio_replicas}}"
         minio_tag: "{{minio_version}}"
+        minio_sc: "{{minio_storage_class}}"
 
     # Pachyderm
     - name: Pachyderm

--- a/playbooks/roles/minio/tasks/main.yml
+++ b/playbooks/roles/minio/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: install Minio
   command: >
     helm upgrade --install 
-    --set imageTag="{{ minio_tag }}",accessKey="{{ minio_accesskey }}",secretKey="{{ minio_secretkey }}",mode=shared,replicas="{{ minio_replicas }}",serviceType=ClusterIP,persistence.size="{{ minio_pvc_size }}",persistence.accessMode=ReadWriteMany,defaultBucket.enabled=true,defaultBucket.name=defaultbucket
+    --set imageTag="{{ minio_tag }}",accessKey="{{ minio_accesskey }}",secretKey="{{ minio_secretkey }}",mode=shared,replicas="{{ minio_replicas }}",serviceType=ClusterIP,persistence.size="{{ minio_pvc_size }}",persistence.storageClass="{{ minio_sc }}",persistence.accessMode=ReadWriteMany,defaultBucket.enabled=true,defaultBucket.name=defaultbucket
     "{{ minio_release_name }}" stable/minio
 
 - name: wait for Minio to be Running


### PR DESCRIPTION
This PR updates the `storageClass` used by the Minio service. It requires the `object-storage-sc` class definition.